### PR TITLE
Don't try to arcade-machine-ify inputs that would have an effect in html forms

### DIFF
--- a/demo/src/bundles/demo/demo.module.ts
+++ b/demo/src/bundles/demo/demo.module.ts
@@ -52,16 +52,24 @@ import 'rxjs/add/observable/interval';
     }
 
     form {
+      display: flex;
       margin: 15px;
+      align-content: center;
     }
 
-    input, button {
+    form div {
+      margin-right: 5px;
+    }
+
+    input, button, textarea {
       border: 1px solid #000;
+      padding: 5px 8px;
       border-radius: 0;
       box-shadow: 0;
+      outline: 0 !important;
     }
 
-    input.arc--selected, button.arc--selected {
+    input.arc--selected, button.arc--selected, textarea.arc--selected {
       border-color: #f00;
     }
   `],
@@ -121,9 +129,10 @@ import 'rxjs/add/observable/interval';
     <h1>A Form</h1>
     <div class="area">
       <form (submit)="alert('Submitting form')">
-        <input placeholder="Username">
-        <input placeholder="Password" type="password">
-        <button>Submit</button>
+        <div><input placeholder="Username"></div>
+        <div><input placeholder="Password" type="password"></div>
+        <div><textarea></textarea></div>
+        <div><button>Submit</button></div>
       </form>
     </div>
 

--- a/src/focus.service.ts
+++ b/src/focus.service.ts
@@ -233,7 +233,7 @@ export class FocusService {
   private registrySubscription: Subscription;
 
   // The currently selected element.
-  private selected: Element;
+  public selected: Element;
   // Parents of the selected element.
   private parents: Element[] = [];
   // The client bounding rect when we first selected the element, cached

--- a/src/input.service.ts
+++ b/src/input.service.ts
@@ -210,15 +210,14 @@ function isForForm(direction: Direction, selected: Element): boolean {
   // Deal with the output ourselves, allowing arcade-machine to handle it only
   // if the key press would not have any effect in the context of the input.
   const input = <HTMLInputElement | HTMLTextAreaElement> selected;
-  const start = input.selectionStart as number;
-  const end = input.selectionEnd as number;
-  if (start !== end) { // key input on any range selection will be effectual.
+  const cursor = input.selectionStart;
+  if (cursor !== input.selectionEnd) { // key input on any range selection will be effectual.
     return true;
   }
 
-  return (start > 0 && direction === Direction.LEFT)
-    || (start > 0 && direction === Direction.BACK)
-    || (start < input.value.length && direction === Direction.RIGHT);
+  return (cursor > 0 && direction === Direction.LEFT)
+    || (cursor > 0 && direction === Direction.BACK)
+    || (cursor < input.value.length && direction === Direction.RIGHT);
 }
 
 /**

--- a/src/input.service.ts
+++ b/src/input.service.ts
@@ -181,7 +181,7 @@ function isForForm(direction: Direction, selected: Element): boolean {
   }
 
   // Always allow the browser to handle enter key presses. This will either
-  // submit the form or put a line break in a textarea (if enter is not held).
+  // submit the form or put a line break in a textarea (if control is not held).
   if (direction === Direction.SUBMIT) {
     return true;
   }

--- a/src/input.service.ts
+++ b/src/input.service.ts
@@ -197,7 +197,6 @@ function isForForm(direction: Direction, selected: Element): boolean {
   }
 
   // Enter key presses on textareas can be handled normally.
-  // todo(connor4312): handle control+enter
   if (tag === 'TEXTAREA' && direction === Direction.SUBMIT) {
     return true;
   }

--- a/src/input.service.ts
+++ b/src/input.service.ts
@@ -180,28 +180,20 @@ function isForForm(direction: Direction, selected: Element): boolean {
     return false;
   }
 
-  // If we hit enter and we weren't in a text area, let the form handle it.
-  const tag = selected.tagName;
-  if (direction === Direction.SUBMIT && tag !== 'TEXTAREA') {
-    for (let parent = selected.parentElement; parent; parent = parent.parentElement) {
-      if (parent.tagName === 'FORM') {
-        return true;
-      }
-    }
+  // Always allow the browser to handle enter key presses. This will either
+  // submit the form or put a line break in a textarea (if enter is not held).
+  if (direction === Direction.SUBMIT) {
+    return true;
   }
 
-  // Okay, no form? Well, if we aren't inside a textbox, go ahead and let
-  // arcade-machine try to deal with the output.
+  // Okay, not a submission? Well, if we aren't inside a text input, go ahead
+  // and let arcade-machine try to deal with the output.
+  const tag = selected.tagName;
   if (tag !== 'INPUT' && tag !== 'TEXTAREA') {
     return false;
   }
 
-  // Enter key presses on textareas can be handled normally.
-  if (tag === 'TEXTAREA' && direction === Direction.SUBMIT) {
-    return true;
-  }
-
-  // We'll say that up/down has no effect either.
+  // We'll say that up/down has no effect.
   if (direction === Direction.DOWN || direction === Direction.UP) {
     return false;
   }

--- a/src/input.service.ts
+++ b/src/input.service.ts
@@ -429,7 +429,6 @@ export class InputService {
         return;
       }
 
-        console.log(direction);
       result = !isForForm(direction, this.focus.selected)
         && this.handleDirection(direction);
     });


### PR DESCRIPTION
Previously arcade-machine would try to capture backspaces, arrow keys, and enter keys on all form elements, making it quite frustrating. I've added logic that prevents that, see demo: https://peet.io/i/16-11-c1zu8u9ga2xo0jgvka5o9v7385ej12.mp4

Note that this _only_ affects keyboard input on PC.