### PR TITLE
Disable nav on inputpane

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/core-js": "^0.9.34",
     "@types/jasmine": "^2.5.35",
     "@types/node": "^6.0.45",
+    "@types/winrt-uwp": "0.0.16",
     "awesome-typescript-loader": "^2.2.4",
     "clean-webpack-plugin": "^0.1.10",
     "codelyzer": "0.0.28",

--- a/src/input.service.ts
+++ b/src/input.service.ts
@@ -4,6 +4,7 @@ import { EventEmitter, Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 import { Subscription } from 'rxjs/Subscription';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import 'rxjs/add/observable/fromEvent';
 import 'rxjs/add/observable/merge';
@@ -263,8 +264,8 @@ function isForForm(direction: Direction, selected: Element): boolean {
 @Injectable()
 export class InputService {
 
-  public inputPane : Windows.UI.ViewManagement.InputPane = Windows.UI.ViewManagement.InputPane.getForCurrentView();
-  public keyboardVisible : boolean = false;
+  private inputPane : Windows.UI.ViewManagement.InputPane = Windows.UI.ViewManagement.InputPane.getForCurrentView();
+  public keyboardVisible : BehaviorSubject<boolean> = new BehaviorSubject(false);
 
   /**
    * DirectionCodes is a map of directions to key code names.
@@ -397,11 +398,11 @@ export class InputService {
   }
 
   private handleKeyboardShow() {
-    this.keyboardVisible = true;
+    this.keyboardVisible.next(true);
   }
 
   private handleKeyboardHide() {
-    this.keyboardVisible = false;
+    this.keyboardVisible.next(false);
   }
 
   /**
@@ -488,7 +489,7 @@ export class InputService {
         continue;
       }
 
-      if (this.keyboardVisible) {
+      if (this.keyboardVisible.getValue()) {
         continue;
       }
 

--- a/src/input.service.ts
+++ b/src/input.service.ts
@@ -7,6 +7,7 @@ import { Subscription } from 'rxjs/Subscription';
 
 import 'rxjs/add/observable/fromEvent';
 import 'rxjs/add/observable/merge';
+import 'rxjs/add/operator/do';
 
 interface IGamepadWrapper {
   // Directional returns from the gamepad. They debounce themselves and
@@ -263,6 +264,9 @@ function isForForm(direction: Direction, selected: Element): boolean {
 @Injectable()
 export class InputService {
 
+  public inputPane : Windows.UI.ViewManagement.InputPane = Windows.UI.ViewManagement.InputPane.getForCurrentView();
+  public keyboardVisible : boolean = false;
+
   /**
    * DirectionCodes is a map of directions to key code names.
    */
@@ -388,6 +392,17 @@ export class InputService {
       Observable.fromEvent<FocusEvent>(document, 'focusin', { passive: true })
         .subscribe(ev => this.focus.onFocusChange(<Element>ev.target))
     );
+
+    this.inputPane.onshowing = this.handleKeyboardShow.bind(this);
+    this.inputPane.onhiding = this.handleKeyboardHide.bind(this);
+  }
+
+  private handleKeyboardShow() {
+    this.keyboardVisible = true;
+  }
+
+  private handleKeyboardHide() {
+    this.keyboardVisible = false;
   }
 
   /**
@@ -471,6 +486,10 @@ export class InputService {
 
       if (!gamepad.isConnected()) {
         delete this.gamepads[rawpads[i].id];
+        continue;
+      }
+
+      if (this.keyboardVisible) {
         continue;
       }
 

--- a/src/input.service.ts
+++ b/src/input.service.ts
@@ -7,7 +7,6 @@ import { Subscription } from 'rxjs/Subscription';
 
 import 'rxjs/add/observable/fromEvent';
 import 'rxjs/add/observable/merge';
-import 'rxjs/add/operator/do';
 
 interface IGamepadWrapper {
   // Directional returns from the gamepad. They debounce themselves and

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,8 @@
         ],
         "types": [
             "jasmine",
-            "node"
+            "node",
+            "winrt-uwp"
         ]
     },
     "exclude": [


### PR DESCRIPTION
Disable navigation when input pane is visible. This will make arcade machine specific to UWP though, which I guess is fine?