### PR TITLE
scrolling now aware of safety padding container

### DIFF
--- a/src/focus.service.ts
+++ b/src/focus.service.ts
@@ -221,13 +221,6 @@ function isDirectional(ev: Direction) {
 }
 
 /**
- * Linearly interpolates between two numbers.
- */
-// function lerp(start: number, end: number, progress: number): number {
-//   return start + (end - start) * progress;
-// }
-
-/**
  * Interpolation with quadratic speed up and slow down.
  */
 function quad(start: number, end: number, progress: number): number {


### PR DESCRIPTION
FocusService now regards root as a the element to operate in when it comes to scrolling.

Also fixed a bug where if multiple animates are triggered during scrolling, only the last one will be activated because top is updated before the animation is actually carried out