### PR TITLE
Distinguish incoming and outgoing focuses, allow support for custom event attaches

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ When `arc-focus` is on an element, that element will steal the page focus when i
 export interface IArcEvent {
   // The 'arc' directive reference, may not be filled for elements which
   // are focusable without the directive, like form controls.
-  readonly directive?: IArcDirective;
+  readonly directive?: IArcHandler;
   // `next` is the element that we'll select next, on directional navigation,
   // unless the element is cancelled. This *is* settable and you can use it
   // to modify the focus target. This will be set to `null` on non-directional

--- a/src/arc.directive.ts
+++ b/src/arc.directive.ts
@@ -1,4 +1,4 @@
-import { Direction, IArcDirective, IArcEvent } from './model';
+import { Direction, IArcHandler, IArcEvent } from './model';
 import { RegistryService } from './registry.service';
 import {
   Directive,
@@ -30,7 +30,7 @@ function createDirectionCapture(direction: Direction, target: HTMLElement) {
 }
 
 @Directive({ selector: '[arc]' })
-export class ArcDirective implements OnInit, OnDestroy, IArcDirective {
+export class ArcDirective implements OnInit, OnDestroy, IArcHandler {
 
   // 'Primitive' I/O handlers: ================================================
 
@@ -46,6 +46,11 @@ export class ArcDirective implements OnInit, OnDestroy, IArcDirective {
   @Input('arc-default-focus')
   public set arcDefaultFocus(_ignored: any) {
     this.arcSetFocus = this.arcSetFocus.startWith(undefined);
+  }
+
+  @Input('arc-exclude-this')
+  public set arcExcludeThis(exclude: any) {
+    this.excludeThis = exclude !== false;
   }
 
   // Directional/event shortcuts: =============================================
@@ -77,6 +82,7 @@ export class ArcDirective implements OnInit, OnDestroy, IArcDirective {
   }
 
   private handlers: ((ev: IArcEvent) => void)[] = [];
+  private excludeThis = false;
 
   constructor(
     private el: ElementRef,
@@ -96,7 +102,11 @@ export class ArcDirective implements OnInit, OnDestroy, IArcDirective {
     return this.el.nativeElement;
   }
 
-  public fireEvent(ev: IArcEvent) {
+  public exclude() {
+    return this.excludeThis;
+  }
+
+  public onOutgoing(ev: IArcEvent) {
     this.arcCapture.emit(ev);
 
     switch (ev.event) {

--- a/src/arc.directive.ts
+++ b/src/arc.directive.ts
@@ -98,15 +98,15 @@ export class ArcDirective implements OnInit, OnDestroy, IArcHandler {
     this.registry.remove(this);
   }
 
-  public getElement() {
+  public getElement(): HTMLElement {
     return this.el.nativeElement;
   }
 
-  public exclude() {
+  public exclude(): boolean {
     return this.excludeThis;
   }
 
-  public onOutgoing(ev: IArcEvent) {
+  public onOutgoing(ev: IArcEvent): void {
     this.arcCapture.emit(ev);
 
     switch (ev.event) {
@@ -125,7 +125,7 @@ export class ArcDirective implements OnInit, OnDestroy, IArcHandler {
     }
   }
 
-  public onFocus(el: HTMLElement) {
+  public onFocus(el: HTMLElement): void {
     this.arcFocus.next(el);
   }
 }

--- a/src/event.ts
+++ b/src/event.ts
@@ -1,8 +1,8 @@
-import { Direction, IArcDirective, IArcEvent } from './model';
+import { Direction, IArcHandler, IArcEvent } from './model';
 
 export class ArcEvent implements IArcEvent {
 
-  public readonly directive: IArcDirective;
+  public readonly directive: IArcHandler;
   public next: HTMLElement;
 
   public readonly event: Direction;
@@ -12,7 +12,7 @@ export class ArcEvent implements IArcEvent {
   public propagationStopped = false;
 
   constructor(opts: {
-    directive: IArcDirective,
+    directive: IArcHandler,
     next: HTMLElement,
     event: Direction,
     target: HTMLElement

--- a/src/focus.service.ts
+++ b/src/focus.service.ts
@@ -515,7 +515,7 @@ export class FocusService {
   /**
    * Returns if the element can receive focus.
    */
-  private isFocusable(el: HTMLElement) {
+  private isFocusable(el: HTMLElement): boolean {
     const record = this.registry.find(el);
     if (record && record.exclude && record.exclude()) {
       return false;

--- a/src/focus.service.ts
+++ b/src/focus.service.ts
@@ -368,12 +368,20 @@ export class FocusService {
     });
 
     if (isNodeAttached(this.selected, this.root)) {
-      this.bubbleEvent(ev);
+      this.bubbleEvent(ev, false);
     }
 
     // Abort if the user handled
     if (ev.defaultPrevented) {
       return true;
+    }
+
+    // Bubble once more on the target.
+    if (ev.next) {
+      this.bubbleEvent(ev, true, ev.next);
+      if (ev.defaultPrevented) {
+        return true;
+      }
     }
 
     // Otherwise see if we can handle it...
@@ -480,11 +488,8 @@ export class FocusService {
    * Bubbles the ArcEvent from the currently selected element
    * to all parent arc directives.
    */
-  private bubbleEvent(ev: ArcEvent): ArcEvent {
-    for (let el = this.selected;
-      !ev.propagationStopped && el !== this.root;
-      el = el.parentElement) {
-
+  private bubbleEvent(ev: ArcEvent, incoming: boolean, source: HTMLElement = this.selected): ArcEvent {
+    for (let el = source; !ev.propagationStopped && el !== this.root; el = el.parentElement) {
       if (el === undefined) {
         console.warn(
           `arcade-machine focusable element <${el.tagName}> was moved outside of` +
@@ -496,7 +501,11 @@ export class FocusService {
 
       const directive = this.registry.find(el);
       if (directive) {
-        directive.fireEvent(ev);
+        if (incoming && directive.onIncoming) {
+          directive.onIncoming(ev);
+        } else if (!incoming && directive.onOutgoing) {
+          directive.onOutgoing(ev);
+        }
       }
     }
 
@@ -507,17 +516,21 @@ export class FocusService {
    * Returns if the element can receive focus.
    */
   private isFocusable(el: HTMLElement) {
-    const role = el.getAttribute('role');
-    const tabIndex = el.tabIndex;
+    const record = this.registry.find(el);
+    if (record && record.exclude && record.exclude()) {
+      return false;
+    }
 
-    return el.tagName === 'A'
-      || el.tagName === 'BUTTON'
-      || el.tagName === 'INPUT'
-      || el.tagName === 'SELECT'
-      || el.tagName === 'TEXTAREA'
-      || (role && focusableRoles.indexOf(role) > -1)
-      || (tabIndex && tabIndex > -1)
-      || this.registry.find(el) !== undefined;
+    if (el.tabIndex > -1) {
+      return true;
+    }
+
+    const role = el.getAttribute('role');
+    if (role && focusableRoles.indexOf(role) > -1) {
+      return true;
+    }
+
+    return !!record;
   }
 
   /**

--- a/src/model.ts
+++ b/src/model.ts
@@ -26,7 +26,7 @@ export enum Direction {
 export interface IArcEvent {
   // The 'arc' directive reference, may not be filled for elements which
   // are focusable without the directive, like form controls.
-  readonly directive?: IArcDirective;
+  readonly directive?: IArcHandler;
   // `next` is the element that we'll select next, on directional navigation,
   // unless the element is cancelled. This *is* settable and you can use it
   // to modify the focus target. This will be set to `null` on non-directional
@@ -41,7 +41,7 @@ export interface IArcEvent {
   preventDefault(): void;
 }
 
-export interface IArcDirective {
+export interface IArcHandler {
 
   /**
    * Returns the associated DOM element.
@@ -49,12 +49,25 @@ export interface IArcDirective {
   getElement(): HTMLElement;
 
   /**
-   * Calls event handlers for the event.
+   * A method which can return "false" if this handler should not be
+   * included as focusable.
    */
-  fireEvent(ev: IArcEvent): void;
+  exclude?(): boolean;
+
+  /**
+   * Called with an IArcEvent focus is about
+   * to leave this element or one of its children.
+   */
+  onOutgoing?(ev: IArcEvent): void;
+
+  /**
+   * Called with an IArcEvent focus is about
+   * to enter this element or one of its children.
+   */
+  onIncoming?(ev: IArcEvent): void;
 
   /**
    * Triggers a focus change event.
    */
-  onFocus(el: HTMLElement): void;
+  onFocus?(el: HTMLElement): void;
 }

--- a/src/registry.service.ts
+++ b/src/registry.service.ts
@@ -1,4 +1,4 @@
-import { directiveName, IArcDirective } from './model';
+import { IArcHandler } from './model';
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
@@ -8,7 +8,7 @@ import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 @Injectable()
 export class RegistryService {
 
-  private static arcs = new Map<HTMLElement, IArcDirective>();
+  private static arcs = new Map<HTMLElement, IArcHandler>();
 
   /**
    * Subject on which observable can request focus.
@@ -18,22 +18,16 @@ export class RegistryService {
   /**
    * Stores a directive into the registry.
    */
-  public add(arc: IArcDirective) { RegistryService.arcs.set(arc.getElement(), arc); }
+  public add(arc: IArcHandler) { RegistryService.arcs.set(arc.getElement(), arc); }
 
   /**
    * Removes a directive from the registry.
    */
-  public remove(arc: IArcDirective) { RegistryService.arcs.delete(arc.getElement()); }
+  public remove(arc: IArcHandler) { RegistryService.arcs.delete(arc.getElement()); }
 
   /**
    * Returns the ArcDirective associated with the element. Returns
    * undefined if the element has no associated arc.
    */
-  public find(el: HTMLElement) {
-    if (!el.hasAttribute(directiveName)) {
-      return undefined;
-    }
-
-    return RegistryService.arcs.get(el);
-  }
+  public find(el: HTMLElement) { return RegistryService.arcs.get(el); }
 }


### PR DESCRIPTION
In the UI, I needed to bind events to the focus incoming event, without needing to use the directive and instead hooking via the service manually. (A service can optionally be injected, a missing directive will break the build if the directive doesn't exist.) This:

 - renames some stuff and makes it easier to attach custom handlers for elements
 - adds a `arc-exclude-this` to make an element unfocusable ( cc @Antariano ). Note that this does not exclude element children.
 - moves the lifecycle hooks to onIncoming and onOutgoing which are called on the next element and previous element, respectively.
 - flattens down some selection logic; tabIndex is defined to exist on _any_ focusable elements, not just those who explicitly have an index defined. E.g. `<a>asdf</a>` will have a tabIndex of zero. So we can get rid of the explicit tag checking.