### PR TITLE
fixed divs being unselectable

### DIFF
--- a/src/focus.service.ts
+++ b/src/focus.service.ts
@@ -521,7 +521,9 @@ export class FocusService {
       return false;
     }
 
-    if (el.tabIndex < 0) {
+    const tabIndex = el.getAttribute('tabIndex');
+
+    if (!!tabIndex && Number(tabIndex) < 0) {
       return false;
     }
 
@@ -540,8 +542,6 @@ export class FocusService {
     if (role && focusableRoles.indexOf(role) > -1) {
       return true;
     }
-
-    const tabIndex = el.getAttribute('tabIndex');
 
     return el.tagName === 'A'
       || el.tagName === 'BUTTON'


### PR DESCRIPTION
Fixed divs being unselectable even with arc by not allowing tabIndex to default to -1 unless explicitly set.