### PR TITLE
makes checkbox not throw exceptions

### DIFF
--- a/src/input.service.ts
+++ b/src/input.service.ts
@@ -247,7 +247,7 @@ function isForForm(direction: Direction, selected: Element): boolean {
   // if the key press would not have any effect in the context of the input.
   const input = <HTMLInputElement | HTMLTextAreaElement>selected;
 
-  if (input.type === 'checkbox') {
+  if (input.type !== 'text' && input.type !== 'search' && input.type !== 'url' && input.type !== 'tel' && input.type !== 'password') {
     return false;
   }
 

--- a/src/input.service.ts
+++ b/src/input.service.ts
@@ -246,6 +246,11 @@ function isForForm(direction: Direction, selected: Element): boolean {
   // Deal with the output ourselves, allowing arcade-machine to handle it only
   // if the key press would not have any effect in the context of the input.
   const input = <HTMLInputElement | HTMLTextAreaElement>selected;
+
+  if (input.type === 'checkbox') {
+    return false;
+  }
+
   const cursor = input.selectionStart;
   if (cursor !== input.selectionEnd) { // key input on any range selection will be effectual.
     return true;


### PR DESCRIPTION
Chrome used to throw an exception here when it can't read selectionStart and selectionEnd