### PR TITLE
making inputPane public

### DIFF
--- a/src/input.service.ts
+++ b/src/input.service.ts
@@ -272,7 +272,7 @@ export class InputService {
   /**
    * Inputpane and boolean to indicate whether it's visible
    */
-  private inputPane = (<any>window).Windows ? Windows.UI.ViewManagement.InputPane.getForCurrentView() : null;
+  public inputPane = (<any>window).Windows ? Windows.UI.ViewManagement.InputPane.getForCurrentView() : null;
 
   public get keyboardVisible(): boolean {
     return !!this.inputPane && this.inputPane.occludedRect.y !== 0;


### PR DESCRIPTION
so that the consumer of arcade-machine can control the inputPane. I didn't see the point of wrapping the inputPane under one more layer of interface (e.g. `public showInputPane`)