### PR TITLE
Improve arcade-machine focus performance 3-4.5x

### DIFF
--- a/demo/src/bundles/demo/benchmark-page.component.ts
+++ b/demo/src/bundles/demo/benchmark-page.component.ts
@@ -6,9 +6,7 @@ import { FocusService } from '../../../../src';
   template: `
   <div>
     <label>Iterations<input type="number" [(ngModel)]="iterations"></label>
-    <button (click)="runTest(iterations, enableArcExclude, focusTabIndexOnly)">Start Test</button>
-    <label><input type="checkbox" [(ngModel)]="enableArcExclude">enableArcExclude</label>
-    <label><input type="checkbox" [(ngModel)]="focusTabIndexOnly">focusTabIndexOnly</label>
+    <button (click)="runTest(iterations)">Start Test</button>
   </div>
   <div *ngIf="results">
     <h2>Results</h2>
@@ -42,9 +40,6 @@ export class BenchmarkPageComponent {
   public results: string[] = [];
   public testElems = 100;
 
-  public focusTabIndexOnly = false;
-  public enableArcExclude = true;
-
   @ViewChildren('tiles') public tilesElemRef: QueryList<ElementRef>;
 
   constructor(
@@ -53,10 +48,7 @@ export class BenchmarkPageComponent {
     this.initTestElems(this.testElems);
   }
 
-  public runTest(iterations: number, enableArcExclude: boolean, focusTabIndexOnly: boolean) {
-    this.focusService.enableArcExclude = enableArcExclude;
-    this.focusService.focusTabIndexOnly = focusTabIndexOnly;
-
+  public runTest(iterations: number) {
     this.focusService.selectNode(this.tilesElemRef.first.nativeElement, Infinity);
     let keyCode = 39;
     let count = 0;
@@ -67,7 +59,7 @@ export class BenchmarkPageComponent {
       count = count + 1;
       if (count > iterations) {
         const totalDuration = performance.now() - t1;
-        this.results.push(`${totalDuration}ms, focusTabIndexOnly=${focusTabIndexOnly}, enableArcExclude= ${enableArcExclude}`);
+        this.results.push(`${totalDuration}ms`);
         clearInterval(interval);
       }
     });

--- a/demo/src/bundles/demo/page1.component.ts
+++ b/demo/src/bundles/demo/page1.component.ts
@@ -43,7 +43,7 @@ import { Observable } from "rxjs/Observable";
       color: #fff;
     }
 
-    .box.arc--selected {
+    .box:focus {
       background: #f00;
     }
 
@@ -65,7 +65,7 @@ import { Observable } from "rxjs/Observable";
       outline: 0 !important;
     }
 
-    input.arc--selected, button.arc--selected, textarea.arc--selected {
+    input:focus, button:focus, textarea:focus {
       border-color: #f00;
     }
 

--- a/src/arc.directive.ts
+++ b/src/arc.directive.ts
@@ -102,6 +102,9 @@ export class ArcDirective implements OnInit, OnDestroy, IArcHandler {
   public ngOnInit() {
     this.registry.add(this);
     this.arcSetFocus.subscribe(() => this.registry.setFocus.next(this.el.nativeElement));
+    if (!this.innerExclude && !this.innerExcludeThis && this.el.nativeElement.tabIndex === -1) {
+      this.el.nativeElement.tabIndex = 0;
+    }
   }
 
   public ngOnDestroy() {

--- a/src/model.ts
+++ b/src/model.ts
@@ -21,6 +21,20 @@ export enum Direction {
 }
 
 /**
+ * Returns if the direction is left or right.
+ */
+export function isHorizontal(direction: Direction) {
+  return direction === Direction.LEFT || direction === Direction.RIGHT;
+}
+
+/**
+ * Returns if the direction is up or down.
+ */
+export function isVertical(direction: Direction) {
+  return direction === Direction.UP || direction === Direction.DOWN;
+}
+
+/**
  * IArcEvents are fired on an element when an input occurs. They include
  * information about the input and provide utilities similar to standard
  * HTML events.

--- a/src/registry.service.ts
+++ b/src/registry.service.ts
@@ -10,6 +10,7 @@ import { IArcHandler } from './model';
 export class RegistryService {
 
   private static arcs = new Map<HTMLElement, IArcHandler>();
+  private excludedDeepCount = 0;
 
   /**
    * Subject on which observable can request focus.
@@ -19,16 +20,31 @@ export class RegistryService {
   /**
    * Stores a directive into the registry.
    */
-  public add(arc: IArcHandler) { RegistryService.arcs.set(arc.getElement(), arc); }
+  public add(arc: IArcHandler) {
+    RegistryService.arcs.set(arc.getElement(), arc);
+    if (arc.exclude && arc.exclude()) {
+      this.excludedDeepCount++;
+    }
+  }
 
   /**
    * Removes a directive from the registry.
    */
-  public remove(arc: IArcHandler) { RegistryService.arcs.delete(arc.getElement()); }
+  public remove(arc: IArcHandler) {
+    RegistryService.arcs.delete(arc.getElement());
+    if (arc.exclude && arc.exclude()) {
+      this.excludedDeepCount--;
+    }
+  }
 
   /**
    * Returns the ArcDirective associated with the element. Returns
    * undefined if the element has no associated arc.
    */
   public find(el: HTMLElement) { return RegistryService.arcs.get(el); }
+
+  /**
+   * Returns whether there are any elements with deep exclusions in the registry.
+   */
+  public hasExcludedDeepElements(): boolean { return this.excludedDeepCount > 0; }
 }


### PR DESCRIPTION
I forced tabIndex to be set for elements that have the `arc` directive applied. Now that we use tabIndex checks for all things, the explicit focusable role checks can be removed (browsers will automatically set tabIndexes on other focusable elements).  Also, tabIndex is a 'native' property that can be accessed without getAttribute. This also lets us remove the "only tab index" flag and get rid of the class application, since we know the `:focus` selector will always work.

I also dropped the "enable exclusion" flag in favor a feature-detection mechanism. If there are excluded in the elements in the registry, we'll check for them, otherwise we skip it. This makes configuration a little less finicky.

I noticed the isVisible check was taking a good bit of time, so I modified it so that that check is only run on candidate elements rather than on every single element. This reduces the number of times it runs significantly. We also had an unnecessary call to getClientBoundingRect in the rescroll that I got rid of.

There's an old but somewhat [obscure API](https://developer.mozilla.org/en-US/docs/Web/API/Document/elementFromPoint) that lets callers get the topmost element from the DOM at a given x/y position in the screen. It performs well on both Chrome and Edge, calls taking 0.03ms in Edge and about a tenth of that in Chrome. Since we know that we're going in one direction and that _generally_ the item we're focusing is close by on the screen (think browse cards and carousels), we could cast a "ray" outwards from the edge of the currently selected element and see if we hit something interesting. We don't want to search too far, but in most common cases the element we want to select is only a few pixels away from the currently-selected element.

Chrome before: https://peet.io/i/17-03-6b99acd8-5194-46ac-988e-2266643e0608.png
Chrome after (~33%): https://peet.io/i/17-03-36c7dbe3-9968-4b69-a166-a9de1baf1e03.png

Edge before: https://peet.io/i/17-03-1e63c3dc-9bf4-4650-a578-81dca8aa1116.png
Edge after (~23%): https://peet.io/i/17-03-7cc33090-585e-453a-bcd6-d2a3e767579e.png