### PR TITLE
raycast - skip elements not under focus trap

### DIFF
--- a/src/focus.service.ts
+++ b/src/focus.service.ts
@@ -676,7 +676,7 @@ export class FocusService {
         continue;
       }
 
-      if (!isNodeAttached(el, root) || !this.isFocusable(el) || !this.checkFinalFocusable(el)) {
+      if (!isNodeAttached(el, this.focusRoot) || !this.isFocusable(el) || !this.checkFinalFocusable(el)) {
         continue;
       }
 


### PR DESCRIPTION
In focus by raycast; skip elements that are not under focus root. Otherwise focus may move out of focus trap